### PR TITLE
promptパラメータの実装

### DIFF
--- a/src/main/kotlin/com/marblet/idp/application/ClientCallbackUrlGenerator.kt
+++ b/src/main/kotlin/com/marblet/idp/application/ClientCallbackUrlGenerator.kt
@@ -1,0 +1,21 @@
+package com.marblet.idp.application
+
+import com.marblet.idp.domain.model.AuthorizationCode
+import com.marblet.idp.domain.model.RedirectUri
+import org.springframework.stereotype.Service
+import org.springframework.web.util.UriComponentsBuilder
+
+@Service
+class ClientCallbackUrlGenerator {
+    fun generate(
+        redirectUri: RedirectUri,
+        authorizationCode: AuthorizationCode,
+        state: String?,
+    ): String {
+        val builder =
+            UriComponentsBuilder.fromUriString(redirectUri.value)
+                .queryParam("code", authorizationCode.code)
+        state?.let { builder.queryParam("state", it) }
+        return builder.build().toUriString()
+    }
+}

--- a/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
+++ b/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
@@ -4,7 +4,9 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import com.marblet.idp.application.error.AuthorizationApplicationError
+import com.marblet.idp.application.error.AuthorizationApplicationError.LoginRequired
 import com.marblet.idp.domain.model.ClientId
+import com.marblet.idp.domain.model.Prompt
 import com.marblet.idp.domain.model.RedirectUri
 import org.springframework.stereotype.Service
 
@@ -20,10 +22,12 @@ class GetAuthorizeUseCase(
         redirectUri: RedirectUri,
         scope: String?,
         state: String?,
+        prompt: String?,
         loginCookie: String?,
     ): Either<AuthorizationApplicationError, Response> {
-        val request = authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope, loginCookie)
-            .fold({ return it.left() }, { it })
+        val request =
+            authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope, prompt, loginCookie)
+                .fold({ return it.left() }, { it })
         val consentUrl =
             consentUrlGenerator.generate(
                 clientId,
@@ -32,10 +36,13 @@ class GetAuthorizeUseCase(
                 scope,
                 state,
             )
-        if (request.user != null) {
-            return Response(consentUrl).right()
+        if (request.user == null && request.promptSet.contains(Prompt.NONE)) {
+            return LoginRequired.left()
         }
-        return Response(loginUrlGenerator.generate(consentUrl)).right()
+        if (request.user == null || request.promptSet.contains(Prompt.LOGIN) || request.promptSet.contains(Prompt.SELECT_ACCOUNT)) {
+            return Response(loginUrlGenerator.generate(consentUrl)).right()
+        }
+        return Response(consentUrl).right()
     }
 
     data class Response(val redirectUri: String)

--- a/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
+++ b/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import com.marblet.idp.application.error.AuthorizationApplicationError
+import com.marblet.idp.application.error.AuthorizationApplicationError.ConsentRequired
 import com.marblet.idp.application.error.AuthorizationApplicationError.LoginRequired
 import com.marblet.idp.domain.model.AuthorizationCode
 import com.marblet.idp.domain.model.ClientId
@@ -53,6 +54,9 @@ class GetAuthorizeUseCase(
         }
 
         val consent = consentRepository.get(request.user.id, request.client.clientId)
+        if (consent == null && request.promptSet.contains(Prompt.NONE)) {
+            return ConsentRequired.left()
+        }
         if (consent == null ||
             !consent.satisfies(request.requestScopes) ||
             request.promptSet.contains(Prompt.CONSENT)

--- a/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
+++ b/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
@@ -66,8 +66,8 @@ class GetAuthorizeUseCase(
                 clientId,
                 ConsentedScopes(request.requestScopes.value),
                 redirectUri,
+                authorizationCodeRepository,
             )
-        authorizationCodeRepository.insert(authorizationCode)
 
         val callbackUri = clientCallbackUrlGenerator.generate(redirectUri, authorizationCode, state)
 

--- a/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
+++ b/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
@@ -22,8 +22,8 @@ class GetAuthorizeUseCase(
         state: String?,
         loginCookie: String?,
     ): Either<AuthorizationApplicationError, Response> {
-        authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope, loginCookie)
-            .onLeft { return it.left() }
+        val request = authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope, loginCookie)
+            .fold({ return it.left() }, { it })
         val consentUrl =
             consentUrlGenerator.generate(
                 clientId,
@@ -32,6 +32,9 @@ class GetAuthorizeUseCase(
                 scope,
                 state,
             )
+        if (request.user != null) {
+            return Response(consentUrl).right()
+        }
         return Response(loginUrlGenerator.generate(consentUrl)).right()
     }
 

--- a/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
+++ b/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
@@ -5,9 +5,13 @@ import arrow.core.left
 import arrow.core.right
 import com.marblet.idp.application.error.AuthorizationApplicationError
 import com.marblet.idp.application.error.AuthorizationApplicationError.LoginRequired
+import com.marblet.idp.domain.model.AuthorizationCode
 import com.marblet.idp.domain.model.ClientId
+import com.marblet.idp.domain.model.ConsentedScopes
 import com.marblet.idp.domain.model.Prompt
 import com.marblet.idp.domain.model.RedirectUri
+import com.marblet.idp.domain.repository.AuthorizationCodeRepository
+import com.marblet.idp.domain.repository.ConsentRepository
 import org.springframework.stereotype.Service
 
 @Service
@@ -15,6 +19,9 @@ class GetAuthorizeUseCase(
     private val authorizationRequestValidator: AuthorizationRequestValidator,
     private val consentUrlGenerator: ConsentUrlGenerator,
     private val loginUrlGenerator: LoginUrlGenerator,
+    private val clientCallbackUrlGenerator: ClientCallbackUrlGenerator,
+    private val consentRepository: ConsentRepository,
+    private val authorizationCodeRepository: AuthorizationCodeRepository,
 ) {
     fun run(
         clientId: ClientId,
@@ -28,6 +35,11 @@ class GetAuthorizeUseCase(
         val request =
             authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope, prompt, loginCookie)
                 .fold({ return it.left() }, { it })
+
+        if (request.user == null && request.promptSet.contains(Prompt.NONE)) {
+            return LoginRequired.left()
+        }
+
         val consentUrl =
             consentUrlGenerator.generate(
                 clientId,
@@ -36,13 +48,30 @@ class GetAuthorizeUseCase(
                 scope,
                 state,
             )
-        if (request.user == null && request.promptSet.contains(Prompt.NONE)) {
-            return LoginRequired.left()
-        }
         if (request.user == null || request.promptSet.contains(Prompt.LOGIN) || request.promptSet.contains(Prompt.SELECT_ACCOUNT)) {
             return Response(loginUrlGenerator.generate(consentUrl)).right()
         }
-        return Response(consentUrl).right()
+
+        val consent = consentRepository.get(request.user.id, request.client.clientId)
+        if (consent == null ||
+            !consent.satisfies(request.requestScopes) ||
+            request.promptSet.contains(Prompt.CONSENT)
+        ) {
+            return Response(consentUrl).right()
+        }
+
+        val authorizationCode =
+            AuthorizationCode.generate(
+                request.user.id,
+                clientId,
+                ConsentedScopes(request.requestScopes.value),
+                redirectUri,
+            )
+        authorizationCodeRepository.insert(authorizationCode)
+
+        val callbackUri = clientCallbackUrlGenerator.generate(redirectUri, authorizationCode, state)
+
+        return Response(callbackUri).right()
     }
 
     data class Response(val redirectUri: String)

--- a/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
+++ b/src/main/kotlin/com/marblet/idp/application/GetAuthorizeUseCase.kt
@@ -20,8 +20,9 @@ class GetAuthorizeUseCase(
         redirectUri: RedirectUri,
         scope: String?,
         state: String?,
+        loginCookie: String?,
     ): Either<AuthorizationApplicationError, Response> {
-        authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope)
+        authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope, loginCookie)
             .onLeft { return it.left() }
         val consentUrl =
             consentUrlGenerator.generate(

--- a/src/main/kotlin/com/marblet/idp/application/GetConsentScreenUseCase.kt
+++ b/src/main/kotlin/com/marblet/idp/application/GetConsentScreenUseCase.kt
@@ -21,12 +21,12 @@ class GetConsentScreenUseCase(
         state: String?,
         loginCookie: String?,
     ): Either<AuthorizationApplicationError, Response> {
-        if (loginCookie == null) {
+        val request =
+            authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope, loginCookie)
+                .fold({ return it.left() }, { it })
+        if (request.user == null) {
             return UserNotAuthenticated.left()
         }
-        val request =
-            authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope)
-                .fold({ return it.left() }, { it })
         return Response(request.client.name, request.requestScopes.toSpaceSeparatedString()).right()
     }
 

--- a/src/main/kotlin/com/marblet/idp/application/GetConsentScreenUseCase.kt
+++ b/src/main/kotlin/com/marblet/idp/application/GetConsentScreenUseCase.kt
@@ -19,10 +19,11 @@ class GetConsentScreenUseCase(
         redirectUri: RedirectUri,
         scope: String?,
         state: String?,
+        prompt: String?,
         loginCookie: String?,
     ): Either<AuthorizationApplicationError, Response> {
         val request =
-            authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope, loginCookie)
+            authorizationRequestValidator.validate(clientId, responseType, redirectUri, scope, prompt, loginCookie)
                 .fold({ return it.left() }, { it })
         if (request.user == null) {
             return UserNotAuthenticated.left()

--- a/src/main/kotlin/com/marblet/idp/application/GrantUseCase.kt
+++ b/src/main/kotlin/com/marblet/idp/application/GrantUseCase.kt
@@ -42,8 +42,14 @@ class GrantUseCase(
         }
         val user = userRepository.get(loginCookie) ?: return UserNotFound.left()
 
-        val authorizationCode = AuthorizationCode.generate(user.id, clientId, request.consentedScopes, redirectUri)
-        authorizationCodeRepository.insert(authorizationCode)
+        val authorizationCode =
+            AuthorizationCode.generate(
+                user.id,
+                clientId,
+                request.consentedScopes,
+                redirectUri,
+                authorizationCodeRepository,
+            )
         consentRepository.upsert(Consent(user.id, clientId, request.consentedScopes))
 
         return Response(redirectUri, authorizationCode.code, state).right()

--- a/src/main/kotlin/com/marblet/idp/application/error/AuthorizationApplicationError.kt
+++ b/src/main/kotlin/com/marblet/idp/application/error/AuthorizationApplicationError.kt
@@ -17,4 +17,6 @@ sealed class AuthorizationApplicationError(val error: AuthorizationError, val de
     data object UserNotFound : AuthorizationApplicationError(AuthorizationError.INVALID_REQUEST, "user not found.")
 
     data object UserNotAuthenticated : AuthorizationApplicationError(AuthorizationError.INVALID_REQUEST, "user not logged in.")
+
+    data object LoginRequired : AuthorizationApplicationError(AuthorizationError.INVALID_REQUEST, "login required")
 }

--- a/src/main/kotlin/com/marblet/idp/application/error/AuthorizationApplicationError.kt
+++ b/src/main/kotlin/com/marblet/idp/application/error/AuthorizationApplicationError.kt
@@ -1,6 +1,7 @@
 package com.marblet.idp.application.error
 
 import com.marblet.idp.domain.model.AuthorizationError
+import com.marblet.idp.domain.model.AuthorizationError.CONSENT_REQUIRED
 
 sealed class AuthorizationApplicationError(val error: AuthorizationError, val description: String) {
     data object ClientNotExist : AuthorizationApplicationError(AuthorizationError.INVALID_REQUEST, "client_id is invalid")
@@ -18,5 +19,7 @@ sealed class AuthorizationApplicationError(val error: AuthorizationError, val de
 
     data object UserNotAuthenticated : AuthorizationApplicationError(AuthorizationError.INVALID_REQUEST, "user not logged in.")
 
-    data object LoginRequired : AuthorizationApplicationError(AuthorizationError.INVALID_REQUEST, "login required")
+    data object LoginRequired : AuthorizationApplicationError(AuthorizationError.LOGIN_REQUIRED, "login required.")
+
+    data object ConsentRequired : AuthorizationApplicationError(CONSENT_REQUIRED, "consent required.")
 }

--- a/src/main/kotlin/com/marblet/idp/domain/model/AuthorizationCode.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/AuthorizationCode.kt
@@ -1,5 +1,6 @@
 package com.marblet.idp.domain.model
 
+import com.marblet.idp.domain.repository.AuthorizationCodeRepository
 import java.time.LocalDateTime
 import kotlin.random.Random
 
@@ -21,13 +22,16 @@ class AuthorizationCode(
             clientId: ClientId,
             scopes: ConsentedScopes,
             redirectUri: RedirectUri,
+            authorizationCodeRepository: AuthorizationCodeRepository,
         ): AuthorizationCode {
             val code =
                 (1..CODE_LENGTH)
                     .map { Random.nextInt(0, charPool.size).let { charPool[it] } }
                     .joinToString("")
             val expiration = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES)
-            return AuthorizationCode(code, userId, clientId, scopes, redirectUri, expiration)
+            val authorizationCode = AuthorizationCode(code, userId, clientId, scopes, redirectUri, expiration)
+            authorizationCodeRepository.insert(authorizationCode)
+            return authorizationCode
         }
     }
 

--- a/src/main/kotlin/com/marblet/idp/domain/model/AuthorizationError.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/AuthorizationError.kt
@@ -8,4 +8,6 @@ enum class AuthorizationError(val error: String) {
     INVALID_SCOPE("invalid_scope"),
     SERVER_ERROR("server_error"),
     TEMPORARILY_UNAVAILABLE("temporarily_unavailable"),
+    LOGIN_REQUIRED("login_required"),
+    CONSENT_REQUIRED("consent_required"),
 }

--- a/src/main/kotlin/com/marblet/idp/domain/model/AuthorizationRequest.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/AuthorizationRequest.kt
@@ -1,15 +1,22 @@
 package com.marblet.idp.domain.model
 
-sealed class ValidatedAuthorizationRequest(val client: Client, val responseType: ResponseType, val requestScopes: RequestScopes)
+sealed class ValidatedAuthorizationRequest(
+    val client: Client,
+    val responseType: ResponseType,
+    val requestScopes: RequestScopes,
+    val user: User?,
+)
 
 class OauthAuthorizationRequest(
     client: Client,
     responseType: ResponseType,
     requestScopes: RequestScopes,
-) : ValidatedAuthorizationRequest(client, responseType, requestScopes)
+    user: User?,
+) : ValidatedAuthorizationRequest(client, responseType, requestScopes, user)
 
 class OidcAuthorizationRequest(
     client: Client,
     responseType: ResponseType,
     requestScopes: RequestScopes,
-) : ValidatedAuthorizationRequest(client, responseType, requestScopes)
+    user: User?,
+) : ValidatedAuthorizationRequest(client, responseType, requestScopes, user)

--- a/src/main/kotlin/com/marblet/idp/domain/model/AuthorizationRequest.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/AuthorizationRequest.kt
@@ -4,6 +4,7 @@ sealed class ValidatedAuthorizationRequest(
     val client: Client,
     val responseType: ResponseType,
     val requestScopes: RequestScopes,
+    val promptSet: PromptSet,
     val user: User?,
 )
 
@@ -11,12 +12,14 @@ class OauthAuthorizationRequest(
     client: Client,
     responseType: ResponseType,
     requestScopes: RequestScopes,
+    promptSet: PromptSet,
     user: User?,
-) : ValidatedAuthorizationRequest(client, responseType, requestScopes, user)
+) : ValidatedAuthorizationRequest(client, responseType, requestScopes, promptSet, user)
 
 class OidcAuthorizationRequest(
     client: Client,
     responseType: ResponseType,
     requestScopes: RequestScopes,
+    promptSet: PromptSet,
     user: User?,
-) : ValidatedAuthorizationRequest(client, responseType, requestScopes, user)
+) : ValidatedAuthorizationRequest(client, responseType, requestScopes, promptSet, user)

--- a/src/main/kotlin/com/marblet/idp/domain/model/PromptSet.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/PromptSet.kt
@@ -1,0 +1,30 @@
+package com.marblet.idp.domain.model
+
+data class PromptSet(val prompts: Set<Prompt>) {
+    companion object {
+        fun from(prompt: String?): PromptSet {
+            if (prompt == null) {
+                return PromptSet(setOf())
+            }
+            return PromptSet(prompt.split(" ").mapNotNull { Prompt.find(it) }.toSet())
+        }
+    }
+
+    fun contains(prompt: Prompt): Boolean {
+        return prompts.contains(prompt)
+    }
+}
+
+enum class Prompt(val value: String) {
+    NONE("none"),
+    LOGIN("login"),
+    CONSENT("consent"),
+    SELECT_ACCOUNT("select_account"),
+    ;
+
+    companion object {
+        fun find(value: String): Prompt? {
+            return entries.find { it.value == value }
+        }
+    }
+}

--- a/src/main/kotlin/com/marblet/idp/presentation/AuthorizationController.kt
+++ b/src/main/kotlin/com/marblet/idp/presentation/AuthorizationController.kt
@@ -8,6 +8,7 @@ import com.marblet.idp.domain.model.RedirectUri
 import com.marblet.idp.presentation.dto.ErrorResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -26,6 +27,7 @@ class AuthorizationController(
         @RequestParam(name = "redirect_uri") redirectUri: String,
         @RequestParam scope: String?,
         @RequestParam state: String?,
+        @CookieValue("login") loginCookie: String?,
     ): ResponseEntity<Void> {
         return getAuthorizeUseCase.run(
             ClientId(clientId),
@@ -33,6 +35,7 @@ class AuthorizationController(
             RedirectUri(redirectUri),
             scope,
             state,
+            loginCookie
         ).fold(
             { throw GetAuthorizeException(it, state) },
             { ResponseEntity.status(HttpStatus.FOUND).header("Location", it.redirectUri).build() },

--- a/src/main/kotlin/com/marblet/idp/presentation/AuthorizationController.kt
+++ b/src/main/kotlin/com/marblet/idp/presentation/AuthorizationController.kt
@@ -27,6 +27,7 @@ class AuthorizationController(
         @RequestParam(name = "redirect_uri") redirectUri: String,
         @RequestParam scope: String?,
         @RequestParam state: String?,
+        @RequestParam prompt: String?,
         @CookieValue("login") loginCookie: String?,
     ): ResponseEntity<Void> {
         return getAuthorizeUseCase.run(
@@ -35,7 +36,8 @@ class AuthorizationController(
             RedirectUri(redirectUri),
             scope,
             state,
-            loginCookie
+            prompt,
+            loginCookie,
         ).fold(
             { throw GetAuthorizeException(it, state) },
             { ResponseEntity.status(HttpStatus.FOUND).header("Location", it.redirectUri).build() },

--- a/src/main/kotlin/com/marblet/idp/presentation/ConsentController.kt
+++ b/src/main/kotlin/com/marblet/idp/presentation/ConsentController.kt
@@ -30,6 +30,7 @@ class ConsentController(
         @RequestParam(name = "redirect_uri") redirectUri: String,
         @RequestParam scope: String?,
         @RequestParam state: String?,
+        @RequestParam prompt: String?,
         @CookieValue("login") loginCookie: String?,
         model: Model,
     ): String {
@@ -39,6 +40,7 @@ class ConsentController(
             RedirectUri(redirectUri),
             scope,
             state,
+            prompt,
             loginCookie,
         ).fold(
             { throw GetConsentScreenException(it, state) },

--- a/src/test/kotlin/com/marblet/idp/domain/model/AuthorizationCodeTest.kt
+++ b/src/test/kotlin/com/marblet/idp/domain/model/AuthorizationCodeTest.kt
@@ -1,5 +1,6 @@
 package com.marblet.idp.domain.model
 
+import com.marblet.idp.domain.repository.AuthorizationCodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -11,10 +12,12 @@ class AuthorizationCodeTest {
         val clientId = ClientId("client-1")
         val scopes = ConsentedScopes(setOf("a", "b"))
         val redirectUri = RedirectUri("test")
+        val authorizationCodeRepository = DummyAuthorizationCodeRepository()
 
-        val actual = AuthorizationCode.generate(userId, clientId, scopes, redirectUri)
+        val actual = AuthorizationCode.generate(userId, clientId, scopes, redirectUri, authorizationCodeRepository)
 
         assertThat(actual.code.length).isEqualTo(32)
+        authorizationCodeRepository.haveBeenCalledOnceWith(actual)
     }
 
     @Test
@@ -23,10 +26,12 @@ class AuthorizationCodeTest {
         val clientId = ClientId("client-1")
         val scopes = ConsentedScopes(setOf("a", "b"))
         val redirectUri = RedirectUri("test")
+        val authorizationCodeRepository = DummyAuthorizationCodeRepository()
 
-        val actual = AuthorizationCode.generate(userId, clientId, scopes, redirectUri)
+        val actual = AuthorizationCode.generate(userId, clientId, scopes, redirectUri, authorizationCodeRepository)
 
         assertThat(actual.code).matches("^[0-9a-zA-Z]+$")
+        authorizationCodeRepository.haveBeenCalledOnceWith(actual)
     }
 
     @Test
@@ -35,12 +40,34 @@ class AuthorizationCodeTest {
         val clientId = ClientId("client-1")
         val scopes = ConsentedScopes(setOf("a", "b"))
         val redirectUri = RedirectUri("test")
+        val authorizationCodeRepository = DummyAuthorizationCodeRepository()
 
-        val actual = AuthorizationCode.generate(userId, clientId, scopes, redirectUri)
+        val actual = AuthorizationCode.generate(userId, clientId, scopes, redirectUri, authorizationCodeRepository)
 
         val currentTime = LocalDateTime.now()
         val expirationThreshold = LocalDateTime.now().plusMinutes(10)
         assertThat(actual.expiration).isAfter(currentTime)
         assertThat(actual.expiration).isBefore(expirationThreshold)
+        authorizationCodeRepository.haveBeenCalledOnceWith(actual)
+    }
+
+    class DummyAuthorizationCodeRepository : AuthorizationCodeRepository {
+        private val history = mutableListOf<AuthorizationCode>()
+
+        override fun insert(authorizationCode: AuthorizationCode) {
+            history.add(authorizationCode)
+        }
+
+        override fun get(code: String): AuthorizationCode? {
+            TODO("Not yet implemented")
+        }
+
+        override fun delete(authorizationCode: AuthorizationCode) {
+            TODO("Not yet implemented")
+        }
+
+        fun haveBeenCalledOnceWith(authorizationCode: AuthorizationCode) {
+            assertThat(history).isEqualTo(listOf(authorizationCode))
+        }
     }
 }

--- a/src/test/kotlin/com/marblet/idp/domain/model/PromptSetTest.kt
+++ b/src/test/kotlin/com/marblet/idp/domain/model/PromptSetTest.kt
@@ -1,0 +1,34 @@
+package com.marblet.idp.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PromptSetTest {
+    @Test
+    fun fromPromptNone() {
+        val actual = PromptSet.from("none")
+
+        assertThat(actual).isEqualTo(PromptSet(setOf(Prompt.NONE)))
+    }
+
+    @Test
+    fun fromPromptLoginAndConsent() {
+        val actual = PromptSet.from("login consent")
+
+        assertThat(actual).isEqualTo(PromptSet(setOf(Prompt.LOGIN, Prompt.CONSENT)))
+    }
+
+    @Test
+    fun fromPromptSelectAccount() {
+        val actual = PromptSet.from("select_account")
+
+        assertThat(actual).isEqualTo(PromptSet(setOf(Prompt.SELECT_ACCOUNT)))
+    }
+
+    @Test
+    fun fromNull() {
+        val actual = PromptSet.from(null)
+
+        assertThat(actual).isEqualTo(PromptSet(setOf()))
+    }
+}


### PR DESCRIPTION
- `prompt=none`
  - ログイン済・同意済ならRedirect URIにリダイレクト
  - そうでなければエラーを返す
- `prompt=login`, `prompt=account_selection`
  - ログイン済か否かにかかわらず、ログイン画面に遷移
- `prompt=consent`
  - 同意済か否かにかかわらず、同意画面に遷移
  - 未ログインの場合はログイン画面に遷移