### PR TITLE
OAuth 2.0 implicit flowの発動条件変更

### DIFF
--- a/docs/protocol_and_flow.md
+++ b/docs/protocol_and_flow.md
@@ -1,16 +1,14 @@
 # 発動するプロトコルとフロー
 
 response_type と scope の値に応じて次の表の通りにプロトコル（OAuth 2.0 / OIDC）とフロー（Authorization Code / Implicit / Hybrid）を発動する。
-この IdP は scope="openid"のみの access_token は発行できない仕様とする。
-そのため、response_type に token を含み、かつ scope が openid のみの場合、Access Token を発行できないのでエラーとして処理する。
-また、response_type に id_token を含み、かつ scope が openid を含まない場合、動作が未定義のためエラーとして処理する。
+response_type が"code token"もしくは id_token を含み、かつ scope が openid を含まない場合、動作が未定義のためエラーとして処理する。
 
 | response_type \ scope | openid + その他 scope   | openid のみ             | openid なし                  |
 | --------------------- | ----------------------- | ----------------------- | ---------------------------- |
-| token                 | OAuth 2.0 Implicit      | invalid_scope           | OAuth 2.0 Implicit           |
+| token                 | OAuth 2.0 Implicit      | OAuth 2.0 Implicit      | OAuth 2.0 Implicit           |
 | code                  | OIDC Authorization Code | OIDC Authorication Code | OAuth 2.0 Authorization Code |
 | id_token              | OIDC Implicit           | OIDC Implicit           | invalid_scope                |
-| id_token token        | OIDC Implicit           | invalid_scope           | invalid_scope                |
-| code token            | OIDC Hybrid             | invalid_scope           | invalid_scope                |
+| id_token token        | OIDC Implicit           | OIDC Hybrid             | invalid_scope                |
+| code token            | OIDC Hybrid             | OIDC Hybrid             | invalid_scope                |
 | code id_token         | OIDC Hybrid             | OIDC Hybrid             | invalid_scope                |
-| code id_token token   | OIDC Hybrid             | invalid_scope           | invalid_scope                |
+| code id_token token   | OIDC Hybrid             | OIDC Hybrid             | invalid_scope                |

--- a/src/main/kotlin/com/marblet/idp/domain/model/AccessTokenPayload.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/AccessTokenPayload.kt
@@ -1,7 +1,6 @@
 package com.marblet.idp.domain.model
 
 import arrow.core.Either
-import arrow.core.Either.Right
 import arrow.core.left
 import arrow.core.right
 import java.time.LocalDateTime
@@ -20,12 +19,11 @@ data class AccessTokenPayload(
             if (authorizationCode.isExpired()) {
                 return CodeExpired().left()
             }
-            val tokenScopes = authorizationCode.scopes.toTokenScopes() ?: return Right(null)
             val issuedAt = LocalDateTime.now()
             return AccessTokenPayload(
                 userId = authorizationCode.userId,
                 clientId = authorizationCode.clientId,
-                scopes = tokenScopes,
+                scopes = authorizationCode.scopes.toTokenScopes(),
                 issuedAt = issuedAt,
                 expiration = issuedAt.plusSeconds(EXPIRATION_SEC),
             ).right()
@@ -66,7 +64,7 @@ data class AccessTokenPayload(
                 userId = validatedGrantRequest.user.id,
                 clientId = validatedGrantRequest.client.clientId,
                 // TODO: remove '!!'
-                scopes = validatedGrantRequest.consentedScopes.toTokenScopes()!!,
+                scopes = validatedGrantRequest.consentedScopes.toTokenScopes(),
                 issuedAt = issuedAt,
                 expiration = issuedAt.plusSeconds(EXPIRATION_SEC),
             )

--- a/src/main/kotlin/com/marblet/idp/domain/model/ConsentedScopes.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/ConsentedScopes.kt
@@ -21,13 +21,8 @@ data class ConsentedScopes(val value: Set<String>) {
 
     fun toSpaceSeparatedString() = value.joinToString(" ")
 
-    fun toTokenScopes(): TokenScopes? {
-        // remove openid scope
-        val scopes = value - OpenidScope.entries.map { it.value }.toSet()
-        if (scopes.isEmpty()) {
-            return null
-        }
-        return TokenScopes(scopes)
+    fun toTokenScopes(): TokenScopes {
+        return TokenScopes(value)
     }
 
     fun hasOpenidScope() = value.contains(OpenidScope.OPENID.value)

--- a/src/main/kotlin/com/marblet/idp/domain/model/RefreshTokenPayload.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/RefreshTokenPayload.kt
@@ -16,12 +16,11 @@ data class RefreshTokenPayload(
             if (authorizationCode.isExpired()) {
                 return null
             }
-            val tokenScopes = authorizationCode.scopes.toTokenScopes() ?: return null
             val issuedAt = LocalDateTime.now()
             return RefreshTokenPayload(
-                authorizationCode.userId,
-                authorizationCode.clientId,
-                tokenScopes,
+                userId = authorizationCode.userId,
+                clientId = authorizationCode.clientId,
+                scopes = authorizationCode.scopes.toTokenScopes(),
                 issuedAt,
                 issuedAt.plusDays(EXPIRATION_DAYS),
             )

--- a/src/main/kotlin/com/marblet/idp/domain/model/TokenScopes.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/TokenScopes.kt
@@ -1,8 +1,7 @@
 package com.marblet.idp.domain.model
 
 /**
- * TokenScopesは、認可コードに持たせるOauth2.0文脈のスコープを表す。
- * "openid"やUserInfoのClaimsとして使われるスコープは、このスコープから除外する。
+ * TokenScopesは、Access TokenやRefresh Tokenのスコープを表す。
  */
 data class TokenScopes(val value: Set<String>) {
     companion object {

--- a/src/main/kotlin/com/marblet/idp/domain/model/ValidatedAuthorizationRequest.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/ValidatedAuthorizationRequest.kt
@@ -29,9 +29,6 @@ class ValidatedAuthorizationRequest private constructor(
             }
             val requestScopes = RequestScopes.generate(scope, client.scopes) ?: return AuthorizationRequestCreateError.ScopeInvalid.left()
             // ref. docs/protocol_and_flow.md
-            if (responseType.hasToken() && requestScopes == RequestScopes(setOf(OpenidScope.OPENID.value))) {
-                return AuthorizationRequestCreateError.ScopeInvalid.left()
-            }
             if (responseType.requiresOpenidScope() && !requestScopes.hasOpenidScope()) {
                 return AuthorizationRequestCreateError.ScopeInvalid.left()
             }

--- a/src/main/kotlin/com/marblet/idp/domain/model/ValidatedGrantRequest.kt
+++ b/src/main/kotlin/com/marblet/idp/domain/model/ValidatedGrantRequest.kt
@@ -30,9 +30,6 @@ class ValidatedGrantRequest private constructor(
             }
             val consentedScopes = ConsentedScopes.generate(scope, client.scopes) ?: return GrantRequestCreateError.ScopeInvalid.left()
             // ref. docs/protocol_and_flow.md
-            if (responseType.hasToken() && consentedScopes == ConsentedScopes(setOf(OpenidScope.OPENID.value))) {
-                return GrantRequestCreateError.ScopeInvalid.left()
-            }
             if (responseType.requiresOpenidScope() && !consentedScopes.hasOpenidScope()) {
                 return GrantRequestCreateError.ScopeInvalid.left()
             }

--- a/src/test/kotlin/com/marblet/idp/domain/model/ConsentedScopesTest.kt
+++ b/src/test/kotlin/com/marblet/idp/domain/model/ConsentedScopesTest.kt
@@ -37,22 +37,4 @@ class ConsentedScopesTest {
 
         assertThat(actual).isFalse()
     }
-
-    @Test
-    fun returnTokenScopeIfAccessTokenScopesExist() {
-        val target = ConsentedScopes(setOf("openid", "email", "a", "b"))
-
-        val actual = target.toTokenScopes()
-
-        assertThat(actual).isEqualTo(TokenScopes(setOf("email", "a", "b")))
-    }
-
-    @Test
-    fun returnNullIfAccessTokenScopesNotExist() {
-        val target = ConsentedScopes(setOf("openid"))
-
-        val actual = target.toTokenScopes()
-
-        assertThat(actual).isNull()
-    }
 }

--- a/src/test/kotlin/com/marblet/idp/domain/model/ValidatedAuthorizationRequestTest.kt
+++ b/src/test/kotlin/com/marblet/idp/domain/model/ValidatedAuthorizationRequestTest.kt
@@ -73,7 +73,7 @@ class ValidatedAuthorizationRequestTest {
         }
 
         @Test
-        fun invalidScopeError() {
+        fun generateRequestOfOpenidScope() {
             val actual =
                 ValidatedAuthorizationRequest.create(
                     client = client,
@@ -84,7 +84,9 @@ class ValidatedAuthorizationRequestTest {
                     prompt = null,
                 )
 
-            assertThat(actual.leftOrNull()).isEqualTo(ScopeInvalid)
+            val request = actual.getOrNull()
+            assertThat(request?.responseType).isEqualTo(TOKEN)
+            assertThat(request?.requestScopes).isEqualTo(RequestScopes(setOf("openid")))
         }
     }
 

--- a/src/test/kotlin/com/marblet/idp/domain/model/ValidatedGrantRequestTest.kt
+++ b/src/test/kotlin/com/marblet/idp/domain/model/ValidatedGrantRequestTest.kt
@@ -84,7 +84,7 @@ class ValidatedGrantRequestTest {
         }
 
         @Test
-        fun invalidScopeError() {
+        fun generateRequestOfOpenidScope() {
             val actual =
                 ValidatedGrantRequest.create(
                     client = client,
@@ -94,7 +94,8 @@ class ValidatedGrantRequestTest {
                     scope = "openid",
                 )
 
-            assertThat(actual.leftOrNull()).isEqualTo(ScopeInvalid)
+            val request = actual.getOrNull()
+            assertThat(request?.consentedScopes).isEqualTo(ConsentedScopes(setOf("openid")))
         }
     }
 


### PR DESCRIPTION
`response_type=token`かつ`scope=openid`の場合に`scope=openid`を許可するAccess Tokenを発行するように仕様を変更